### PR TITLE
prevent null-objects in cache

### DIFF
--- a/src/main/java/org/jevis/api/sql/SimpleClassCache.java
+++ b/src/main/java/org/jevis/api/sql/SimpleClassCache.java
@@ -70,6 +70,8 @@ public class SimpleClassCache {
             try {
                 System.out.println("Class: " + name + " is not in cache");
                 JEVisClass newClass = _ds.getClassTable().getObjectClass(name);
+                if(newClass == null)
+                    return null;
                 _cach.put(newClass.getName(), newClass);
             } catch (JEVisException ex) {
                 Logger.getLogger(SimpleClassCache.class.getName()).log(Level.SEVERE, null, ex);


### PR DESCRIPTION
- only real object should be cached, when creating a new JEVisClass the new names are not cached to be null